### PR TITLE
RIOT-OS/update: Update version to 22.07

### DIFF
--- a/applications/coap-chat/Makefile
+++ b/applications/coap-chat/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-USEMODULE += gnrc_netdev_default
+USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
 USEMODULE += gnrc_ipv6_default

--- a/applications/coap-chat/coap.c
+++ b/applications/coap-chat/coap.c
@@ -30,7 +30,7 @@
 
 #define COAP_CHAT_PATH      "/chat"
 
-static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
 
 /* CoAP resources */
 static const coap_resource_t _resources[] = {
@@ -43,7 +43,7 @@ static gcoap_listener_t _listener = {
     .next = NULL,
 };
 
-static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
 

--- a/applications/sniffer/Makefile
+++ b/applications/sniffer/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../../RIOT
 # Define modules that are used
 USEMODULE += fmt
 USEMODULE += gnrc
-USEMODULE += gnrc_netdev_default
+USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/applications/sniffer/main.c
+++ b/applications/sniffer/main.c
@@ -26,7 +26,6 @@
 #include "thread.h"
 #include "xtimer.h"
 #include "shell.h"
-#include "shell_commands.h"
 #include "net/gnrc.h"
 
 /**
@@ -63,7 +62,7 @@ void dump_pkt(gnrc_pktsnip_t *pkt)
             pkt = gnrc_pktbuf_remove_snip(pkt, pkt->next);
         }
     }
-    uint64_t now_us = xtimer_usec_from_ticks64(xtimer_now64());
+    uint64_t now_us = xtimer_usec_from_ticks64(xtimer_now());
 
     print_str("rftest-rx --- len ");
     print_u32_hex((uint32_t)gnrc_pkt_len(pkt));


### PR DESCRIPTION
This PR offers update RIOT-OS version and brings support to use all the RIOT-applications in its recently version. All modules used deprecated was removed, the sniffer and the coap-chat was tested and works correctly with these new changes.

### Testing Procedure:

to test coap-chat.

```sh
cd applications/coap-chat
```
```
make flash BOARD=samr21-xpro
```

to test sniffer

```sh
cd applications/sniffer
```
```
make flash BOARD=samr21-xpro
```
```
python3 ./tools/sniffer.py -b 115200 /dev/ttyACM0 26 | wireshark -k -i -
```

Fixes #2 